### PR TITLE
[WEB3-273] EON Explorer Redesign: Display and label backward transfers

### DIFF
--- a/types/api/transaction.ts
+++ b/types/api/transaction.ts
@@ -114,6 +114,7 @@ export type TransactionType = 'rootstock_remasc' |
 'contract_creation' |
 'contract_call' |
 'token_creation' |
-'coin_transfer'
+'coin_transfer' |
+'backward_transfer'
 
 export type TxsResponse = TransactionsResponseValidated | TransactionsResponsePending | BlockTransactionsResponse;

--- a/ui/txs/TxType.tsx
+++ b/ui/txs/TxType.tsx
@@ -9,7 +9,8 @@ export interface Props {
   isLoading?: boolean;
 }
 
-const TYPES_ORDER = [ 'rootstock_remasc', 'rootstock_bridge', 'token_creation', 'contract_creation', 'token_transfer', 'contract_call', 'coin_transfer' ];
+const TYPES_ORDER = [ 'rootstock_remasc', 'rootstock_bridge', 'token_creation', 'contract_creation',
+  'token_transfer', 'contract_call', 'coin_transfer', 'backward_transfer' ];
 
 const TxType = ({ types, isLoading }: Props) => {
   const typeToShow = types.sort((t1, t2) => TYPES_ORDER.indexOf(t1) - TYPES_ORDER.indexOf(t2))[0];
@@ -45,6 +46,10 @@ const TxType = ({ types, isLoading }: Props) => {
     case 'rootstock_bridge':
       label = 'Bridge';
       colorScheme = 'blue';
+      break;
+    case 'backward_transfer':
+      label = 'Backward transfer';
+      colorScheme = 'purple';
       break;
     default:
       label = 'Transaction';

--- a/ui/txs/TxsTableItem.tsx
+++ b/ui/txs/TxsTableItem.tsx
@@ -95,7 +95,7 @@ const TxsTableItem = ({ tx, showBlockInfo, currentAddress, enableTimeIncrement, 
       </Td>
       <Td>
         <VStack alignItems="start">
-          <TxType types={ tx.tx_types } isLoading={ isLoading }/>
+          <TxType types={ tx.method === 'backwardTransfer' ? [ 'backward_transfer' ] : tx.tx_types } isLoading={ isLoading }/>
           <TxStatus status={ tx.status } errorText={ tx.status === 'error' ? tx.result : undefined } isLoading={ isLoading }/>
           <TxWatchListTags tx={ tx } isLoading={ isLoading }/>
         </VStack>


### PR DESCRIPTION
In this PR, we display and add the proper label for backward transfers transactions: 

<img width="1502" alt="image" src="https://github.com/HorizenLabs/blockscout-frontend/assets/36055057/f52377ea-936a-4c6e-b6af-3ffa70b6f1d9">
<img width="1504" alt="image" src="https://github.com/HorizenLabs/blockscout-frontend/assets/36055057/238cc979-7ec4-4aeb-bb5a-2162523f6303">
