### PR TITLE
[WEB3-272] EON Explorer Redesign: Fork blockscout/frontend and add .env templates

### DIFF
--- a/.env.eon
+++ b/.env.eon
@@ -4,7 +4,7 @@ NEXT_PUBLIC_APP_HOST=eon-explorer.horizenlabs.io
 # BLOCKCHAIN PARAMS
 NEXT_PUBLIC_NETWORK_NAME=Horizen EON Mainnet
 NEXT_PUBLIC_NETWORK_ID=7332
-NEXT_PUBLIC_NETWORK_RPC_URL=
+NEXT_PUBLIC_NETWORK_RPC_URL=https://eon-rpc.horizenlabs.io/ethv1
 NEXT_PUBLIC_NETWORK_CURRENCY_NAME=ZEN
 NEXT_PUBLIC_NETWORK_CURRENCY_SYMBOL=ZEN
 NEXT_PUBLIC_NETWORK_CURRENCY_DECIMALS=18
@@ -16,15 +16,14 @@ NEXT_PUBLIC_API_HOST=eon-explorer.horizenlabs.io
 
 # HOMEPAGE
 NEXT_PUBLIC_HOMEPAGE_CHARTS=['daily_txs', 'coin_price', 'market_cap', 'tvl']
-NEXT_PUBLIC_HOMEPAGE_PLATE_TEXT_COLOR=
-NEXT_PUBLIC_HOMEPAGE_PLATE_BACKGROUND=
+NEXT_PUBLIC_HOMEPAGE_PLATE_TEXT_COLOR=white
+NEXT_PUBLIC_HOMEPAGE_PLATE_BACKGROUND=radial-gradient(103.03% 103.03% at 0% 0%, rgba(183, 148, 244, 0.8) 0%, rgba(0, 163, 196, 0.8) 100%), var(--chakra-colors-blue-400)
 
 # SIDEBAR
 NEXT_PUBLIC_NETWORK_LOGO=https://eon-explorer.horizenlabs.io/images/HEON-eon-dark.svg
 NEXT_PUBLIC_NETWORK_LOGO_DARK=https://eon-explorer.horizenlabs.io/images/HEON-eon-light.svg
 NEXT_PUBLIC_NETWORK_ICON=https://eon-explorer.horizenlabs.io/images/favicon-32x32.png
-NEXT_PUBLIC_NETWORK_ICON_DARK=
-# NEXT_PUBLIC_FEATURED_NETWORKS=http://localhost:3000/featured-networks.json
+NEXT_PUBLIC_NETWORK_ICON_DARK=https://eon-explorer.horizenlabs.io/images/favicon-32x32.png
 NEXT_PUBLIC_OTHER_LINKS=[{'url': "https://postman.horizenlabs.io/", 'text': "JSON-RPC Documentation"}, {'url': "https://faucet.horizen.io/", 'text': "Testnet ZEN Faucet"}]
 
 # FOOTER
@@ -42,6 +41,4 @@ NEXT_PUBLIC_AD_BANNER_PROVIDER=none
 NEXT_PUBLIC_AD_TEXT_PROVIDER=none
 
 # CSV
-NEXT_PUBLIC_RE_CAPTCHA_APP_SITE_KEY=
-
-NEXT_PUBLIC_APP_INSTANCE=""
+# NEXT_PUBLIC_RE_CAPTCHA_APP_SITE_KEY=

--- a/.env.eon
+++ b/.env.eon
@@ -1,0 +1,47 @@
+# APP CONFIGURATION
+NEXT_PUBLIC_APP_HOST=eon-explorer.horizenlabs.io
+
+# BLOCKCHAIN PARAMS
+NEXT_PUBLIC_NETWORK_NAME=Horizen EON Mainnet
+NEXT_PUBLIC_NETWORK_ID=7332
+NEXT_PUBLIC_NETWORK_RPC_URL=
+NEXT_PUBLIC_NETWORK_CURRENCY_NAME=ZEN
+NEXT_PUBLIC_NETWORK_CURRENCY_SYMBOL=ZEN
+NEXT_PUBLIC_NETWORK_CURRENCY_DECIMALS=18
+NEXT_PUBLIC_NETWORK_VERIFICATION_TYPE=validation
+NEXT_PUBLIC_IS_TESTNET=false
+
+# API CONFIGURATION
+NEXT_PUBLIC_API_HOST=eon-explorer.horizenlabs.io
+
+# HOMEPAGE
+NEXT_PUBLIC_HOMEPAGE_CHARTS=['daily_txs', 'coin_price', 'market_cap', 'tvl']
+NEXT_PUBLIC_HOMEPAGE_PLATE_TEXT_COLOR=
+NEXT_PUBLIC_HOMEPAGE_PLATE_BACKGROUND=
+
+# SIDEBAR
+NEXT_PUBLIC_NETWORK_LOGO=https://eon-explorer.horizenlabs.io/images/HEON-eon-dark.svg
+NEXT_PUBLIC_NETWORK_LOGO_DARK=https://eon-explorer.horizenlabs.io/images/HEON-eon-light.svg
+NEXT_PUBLIC_NETWORK_ICON=https://eon-explorer.horizenlabs.io/images/favicon-32x32.png
+NEXT_PUBLIC_NETWORK_ICON_DARK=
+# NEXT_PUBLIC_FEATURED_NETWORKS=http://localhost:3000/featured-networks.json
+NEXT_PUBLIC_OTHER_LINKS=[{'url': "https://postman.horizenlabs.io/", 'text': "JSON-RPC Documentation"}, {'url': "https://faucet.horizen.io/", 'text': "Testnet ZEN Faucet"}]
+
+# FOOTER
+NEXT_PUBLIC_FOOTER_LINKS=
+
+# FAVICON
+FAVICON_GENERATOR_API_KEY=87811573d5c5518da21c7c0b669f568bdd9e7004
+
+# METADATA
+NEXT_PUBLIC_OG_DESCRIPTION=The Horizen EON Mainnet Block Explorer allows you to search the Horizen EON Mainnet Blockchain for transactions, addresses, statistics and activities taking place on-chain.
+NEXT_PUBLIC_OG_IMAGE_URL=https://eon-explorer.horizenlabs.io/images/MetaData_image_EON_mainnet_block_explorer.jpg
+
+# FEATURES
+NEXT_PUBLIC_AD_BANNER_PROVIDER=none
+NEXT_PUBLIC_AD_TEXT_PROVIDER=none
+
+# CSV
+NEXT_PUBLIC_RE_CAPTCHA_APP_SITE_KEY=
+
+NEXT_PUBLIC_APP_INSTANCE=""

--- a/.env.gobi
+++ b/.env.gobi
@@ -4,7 +4,7 @@ NEXT_PUBLIC_APP_HOST=gobi-explorer.horizenlabs.io
 # BLOCKCHAIN PARAMS
 NEXT_PUBLIC_NETWORK_NAME=Horizen Gobi Testnet
 NEXT_PUBLIC_NETWORK_ID=1663
-NEXT_PUBLIC_NETWORK_RPC_URL=
+NEXT_PUBLIC_NETWORK_RPC_URL=https://gobi-rpc.horizenlabs.io/ethv1
 NEXT_PUBLIC_NETWORK_CURRENCY_NAME=tZEN
 NEXT_PUBLIC_NETWORK_CURRENCY_SYMBOL=tZEN
 NEXT_PUBLIC_NETWORK_CURRENCY_DECIMALS=18
@@ -12,19 +12,18 @@ NEXT_PUBLIC_NETWORK_VERIFICATION_TYPE=validation
 NEXT_PUBLIC_IS_TESTNET=true
 
 # API CONFIGURATION
-NEXT_PUBLIC_API_HOST=gobi-explorer.horizen.io
+NEXT_PUBLIC_API_HOST=gobi-explorer.horizenlabs.io
 
 # HOMEPAGE
 NEXT_PUBLIC_HOMEPAGE_CHARTS=['daily_txs', 'coin_price', 'market_cap', 'tvl']
-NEXT_PUBLIC_HOMEPAGE_PLATE_TEXT_COLOR=
-NEXT_PUBLIC_HOMEPAGE_PLATE_BACKGROUND=
+NEXT_PUBLIC_HOMEPAGE_PLATE_TEXT_COLOR=white
+NEXT_PUBLIC_HOMEPAGE_PLATE_BACKGROUND=radial-gradient(103.03% 103.03% at 0% 0%, rgba(183, 148, 244, 0.8) 0%, rgba(0, 163, 196, 0.8) 100%), var(--chakra-colors-blue-400)
 
 # SIDEBAR
-NEXT_PUBLIC_NETWORK_LOGO=https://gobi-explorer.horizen.io/images/HEON-gobi.svg
-NEXT_PUBLIC_NETWORK_LOGO_DARK=https://gobi-explorer.horizen.io/images/HEON-gobi-light.svg
-NEXT_PUBLIC_NETWORK_ICON=https://gobi-explorer.horizen.io/images/favicon-32x32.png
-NEXT_PUBLIC_NETWORK_ICON_DARK=
-# NEXT_PUBLIC_FEATURED_NETWORKS=http://localhost:3000/featured-networks.json
+NEXT_PUBLIC_NETWORK_LOGO=https://gobi-explorer.horizenlabs.io/images/HEON-gobi.svg
+NEXT_PUBLIC_NETWORK_LOGO_DARK=https://gobi-explorer.horizenlabs.io/images/HEON-gobi-light.svg
+NEXT_PUBLIC_NETWORK_ICON=https://gobi-explorer.horizenlabs.io/images/favicon-32x32.png
+NEXT_PUBLIC_NETWORK_ICON_DARK=https://pre-gobi-explorer.horizen.io/images/favicon-32x32.png
 NEXT_PUBLIC_OTHER_LINKS=[{'url': "https://postman.horizenlabs.io/", 'text': "JSON-RPC Documentation"}, {'url': "https://faucet.horizen.io/", 'text': "Testnet ZEN Faucet"}]
 
 # FOOTER
@@ -35,13 +34,11 @@ FAVICON_GENERATOR_API_KEY=87811573d5c5518da21c7c0b669f568bdd9e7004
 
 # METADATA
 NEXT_PUBLIC_OG_DESCRIPTION=The Horizen Gobi Testnet Block Explorer allows you to search the Horizen Gobi Testnet Blockchain for transactions, addresses, statistics and activities taking place on-chain.
-NEXT_PUBLIC_OG_IMAGE_URL=https://gobi-explorer.horizen.io/images/MetaData_img_blueprint_gobi_explorer.jpg
+NEXT_PUBLIC_OG_IMAGE_URL=https://gobi-explorer.horizenlabs.io/images/MetaData_img_blueprint_gobi_explorer.jpg
 
 # FEATURES
 NEXT_PUBLIC_AD_BANNER_PROVIDER=none
 NEXT_PUBLIC_AD_TEXT_PROVIDER=none
 
 # CSV
-NEXT_PUBLIC_RE_CAPTCHA_APP_SITE_KEY=
-
-NEXT_PUBLIC_APP_INSTANCE=""
+# NEXT_PUBLIC_RE_CAPTCHA_APP_SITE_KEY=

--- a/.env.gobi
+++ b/.env.gobi
@@ -1,0 +1,47 @@
+# APP CONFIGURATION
+NEXT_PUBLIC_APP_HOST=gobi-explorer.horizenlabs.io
+
+# BLOCKCHAIN PARAMS
+NEXT_PUBLIC_NETWORK_NAME=Horizen Gobi Testnet
+NEXT_PUBLIC_NETWORK_ID=1663
+NEXT_PUBLIC_NETWORK_RPC_URL=
+NEXT_PUBLIC_NETWORK_CURRENCY_NAME=tZEN
+NEXT_PUBLIC_NETWORK_CURRENCY_SYMBOL=tZEN
+NEXT_PUBLIC_NETWORK_CURRENCY_DECIMALS=18
+NEXT_PUBLIC_NETWORK_VERIFICATION_TYPE=validation
+NEXT_PUBLIC_IS_TESTNET=true
+
+# API CONFIGURATION
+NEXT_PUBLIC_API_HOST=gobi-explorer.horizen.io
+
+# HOMEPAGE
+NEXT_PUBLIC_HOMEPAGE_CHARTS=['daily_txs', 'coin_price', 'market_cap', 'tvl']
+NEXT_PUBLIC_HOMEPAGE_PLATE_TEXT_COLOR=
+NEXT_PUBLIC_HOMEPAGE_PLATE_BACKGROUND=
+
+# SIDEBAR
+NEXT_PUBLIC_NETWORK_LOGO=https://gobi-explorer.horizen.io/images/HEON-gobi.svg
+NEXT_PUBLIC_NETWORK_LOGO_DARK=https://gobi-explorer.horizen.io/images/HEON-gobi-light.svg
+NEXT_PUBLIC_NETWORK_ICON=https://gobi-explorer.horizen.io/images/favicon-32x32.png
+NEXT_PUBLIC_NETWORK_ICON_DARK=
+# NEXT_PUBLIC_FEATURED_NETWORKS=http://localhost:3000/featured-networks.json
+NEXT_PUBLIC_OTHER_LINKS=[{'url': "https://postman.horizenlabs.io/", 'text': "JSON-RPC Documentation"}, {'url': "https://faucet.horizen.io/", 'text': "Testnet ZEN Faucet"}]
+
+# FOOTER
+NEXT_PUBLIC_FOOTER_LINKS=
+
+# FAVICON
+FAVICON_GENERATOR_API_KEY=87811573d5c5518da21c7c0b669f568bdd9e7004
+
+# METADATA
+NEXT_PUBLIC_OG_DESCRIPTION=The Horizen Gobi Testnet Block Explorer allows you to search the Horizen Gobi Testnet Blockchain for transactions, addresses, statistics and activities taking place on-chain.
+NEXT_PUBLIC_OG_IMAGE_URL=https://gobi-explorer.horizen.io/images/MetaData_img_blueprint_gobi_explorer.jpg
+
+# FEATURES
+NEXT_PUBLIC_AD_BANNER_PROVIDER=none
+NEXT_PUBLIC_AD_TEXT_PROVIDER=none
+
+# CSV
+NEXT_PUBLIC_RE_CAPTCHA_APP_SITE_KEY=
+
+NEXT_PUBLIC_APP_INSTANCE=""

--- a/.env.pregobi
+++ b/.env.pregobi
@@ -1,0 +1,47 @@
+# APP CONFIGURATION
+NEXT_PUBLIC_APP_HOST=pre-gobi-explorer.horizenlabs.io
+
+# BLOCKCHAIN PARAMS
+NEXT_PUBLIC_NETWORK_NAME=Horizen Pre-Gobi Testnet
+NEXT_PUBLIC_NETWORK_ID=1663
+NEXT_PUBLIC_NETWORK_RPC_URL=
+NEXT_PUBLIC_NETWORK_CURRENCY_NAME=tZEN
+NEXT_PUBLIC_NETWORK_CURRENCY_SYMBOL=tZEN
+NEXT_PUBLIC_NETWORK_CURRENCY_DECIMALS=18
+NEXT_PUBLIC_NETWORK_VERIFICATION_TYPE=validation
+NEXT_PUBLIC_IS_TESTNET=true
+
+# API CONFIGURATION
+NEXT_PUBLIC_API_HOST=pre-gobi-explorer.horizen.io
+
+# HOMEPAGE
+NEXT_PUBLIC_HOMEPAGE_CHARTS=['daily_txs', 'coin_price', 'market_cap', 'tvl']
+NEXT_PUBLIC_HOMEPAGE_PLATE_TEXT_COLOR=
+NEXT_PUBLIC_HOMEPAGE_PLATE_BACKGROUND=
+
+# SIDEBAR
+NEXT_PUBLIC_NETWORK_LOGO=https://pre-gobi-explorer.horizen.io/images/HEON-gobi.svg
+NEXT_PUBLIC_NETWORK_LOGO_DARK=https://pre-gobi-explorer.horizen.io/images/HEON-gobi-light.svg
+NEXT_PUBLIC_NETWORK_ICON=https://pre-gobi-explorer.horizen.io/images/favicon-32x32.png
+NEXT_PUBLIC_NETWORK_ICON_DARK=
+# NEXT_PUBLIC_FEATURED_NETWORKS=http://localhost:3000/featured-networks.json
+NEXT_PUBLIC_OTHER_LINKS=[{'url': "https://postman.horizenlabs.io/", 'text': "JSON-RPC Documentation"}, {'url': "https://faucet.horizen.io/", 'text': "Testnet ZEN Faucet"}]
+
+# FOOTER
+NEXT_PUBLIC_FOOTER_LINKS=
+
+# FAVICON
+FAVICON_GENERATOR_API_KEY=87811573d5c5518da21c7c0b669f568bdd9e7004
+
+# METADATA
+NEXT_PUBLIC_OG_DESCRIPTION=The Horizen Gobi Testnet Block Explorer allows you to search the Horizen Gobi Testnet Blockchain for transactions, addresses, statistics and activities taking place on-chain.
+NEXT_PUBLIC_OG_IMAGE_URL=https://pre-gobi-explorer.horizen.io/images/MetaData_img_blueprint_gobi_explorer.jpg
+
+# FEATURES
+NEXT_PUBLIC_AD_BANNER_PROVIDER=none
+NEXT_PUBLIC_AD_TEXT_PROVIDER=none
+
+# CSV
+NEXT_PUBLIC_RE_CAPTCHA_APP_SITE_KEY=
+
+NEXT_PUBLIC_APP_INSTANCE=""

--- a/.env.pregobi
+++ b/.env.pregobi
@@ -4,7 +4,7 @@ NEXT_PUBLIC_APP_HOST=pre-gobi-explorer.horizenlabs.io
 # BLOCKCHAIN PARAMS
 NEXT_PUBLIC_NETWORK_NAME=Horizen Pre-Gobi Testnet
 NEXT_PUBLIC_NETWORK_ID=1663
-NEXT_PUBLIC_NETWORK_RPC_URL=
+NEXT_PUBLIC_NETWORK_RPC_URL=https://pregobi-explorer-rpc.horizenlabs.io/ethv1
 NEXT_PUBLIC_NETWORK_CURRENCY_NAME=tZEN
 NEXT_PUBLIC_NETWORK_CURRENCY_SYMBOL=tZEN
 NEXT_PUBLIC_NETWORK_CURRENCY_DECIMALS=18
@@ -16,15 +16,14 @@ NEXT_PUBLIC_API_HOST=pre-gobi-explorer.horizen.io
 
 # HOMEPAGE
 NEXT_PUBLIC_HOMEPAGE_CHARTS=['daily_txs', 'coin_price', 'market_cap', 'tvl']
-NEXT_PUBLIC_HOMEPAGE_PLATE_TEXT_COLOR=
-NEXT_PUBLIC_HOMEPAGE_PLATE_BACKGROUND=
+NEXT_PUBLIC_HOMEPAGE_PLATE_TEXT_COLOR=white
+NEXT_PUBLIC_HOMEPAGE_PLATE_BACKGROUND=radial-gradient(103.03% 103.03% at 0% 0%, rgba(183, 148, 244, 0.8) 0%, rgba(0, 163, 196, 0.8) 100%), var(--chakra-colors-blue-400)
 
 # SIDEBAR
 NEXT_PUBLIC_NETWORK_LOGO=https://pre-gobi-explorer.horizen.io/images/HEON-gobi.svg
 NEXT_PUBLIC_NETWORK_LOGO_DARK=https://pre-gobi-explorer.horizen.io/images/HEON-gobi-light.svg
 NEXT_PUBLIC_NETWORK_ICON=https://pre-gobi-explorer.horizen.io/images/favicon-32x32.png
-NEXT_PUBLIC_NETWORK_ICON_DARK=
-# NEXT_PUBLIC_FEATURED_NETWORKS=http://localhost:3000/featured-networks.json
+NEXT_PUBLIC_NETWORK_ICON_DARK=https://pre-gobi-explorer.horizen.io/images/favicon-32x32.png
 NEXT_PUBLIC_OTHER_LINKS=[{'url': "https://postman.horizenlabs.io/", 'text': "JSON-RPC Documentation"}, {'url': "https://faucet.horizen.io/", 'text': "Testnet ZEN Faucet"}]
 
 # FOOTER
@@ -42,6 +41,4 @@ NEXT_PUBLIC_AD_BANNER_PROVIDER=none
 NEXT_PUBLIC_AD_TEXT_PROVIDER=none
 
 # CSV
-NEXT_PUBLIC_RE_CAPTCHA_APP_SITE_KEY=
-
-NEXT_PUBLIC_APP_INSTANCE=""
+# NEXT_PUBLIC_RE_CAPTCHA_APP_SITE_KEY=


### PR DESCRIPTION
EON Mainnet:
<img width="2039" alt="image" src="https://github.com/HorizenLabs/blockscout-frontend/assets/36055057/7e8d01ad-71b5-4ca4-9b05-7fad5286bd5a">

Gobi Testnet:
<img width="2030" alt="image" src="https://github.com/HorizenLabs/blockscout-frontend/assets/36055057/ad30e5ff-d2f7-4bf0-ad49-96fe91481759">

Pre-Gobi Testnet:
<img width="2036" alt="image" src="https://github.com/HorizenLabs/blockscout-frontend/assets/36055057/17f724aa-0031-41ce-8c45-4bd06c2e1bd7">
