### PR TITLE
[WEB3-559] Gas Tracker: hide tooltip and use gas price from rpc

### DIFF
--- a/mocks/stats/index.ts
+++ b/mocks/stats/index.ts
@@ -8,6 +8,7 @@ export const base: HomeStats = {
     fast: 67.5,
     slow: 48.0,
   },
+  gas_price_rpc: 48.0,
   gas_used_today: '4108680603',
   market_cap: '330809.96443288102524',
   network_utilization_percentage: 1.55372064,

--- a/stubs/stats.ts
+++ b/stubs/stats.ts
@@ -8,6 +8,7 @@ export const HOMEPAGE_STATS: HomeStats = {
     fast: 0.11,
     slow: 0.1,
   },
+  gas_price_rpc: 0.1,
   gas_used_today: '0',
   market_cap: '0',
   network_utilization_percentage: 22.56,

--- a/types/api/stats.ts
+++ b/types/api/stats.ts
@@ -8,6 +8,7 @@ export type HomeStats = {
   transactions_today: string;
   gas_used_today: string;
   gas_prices: GasPrices | null;
+  gas_price_rpc: number | null;
   static_gas_price: string | null;
   market_cap: string;
   network_utilization_percentage: number;

--- a/ui/home/Stats.tsx
+++ b/ui/home/Stats.tsx
@@ -16,7 +16,6 @@ import useApiQuery from 'lib/api/useApiQuery';
 import { WEI } from 'lib/consts';
 import { HOMEPAGE_STATS } from 'stubs/stats';
 
-import StatsGasPrices from './StatsGasPrices';
 import StatsItem from './StatsItem';
 
 const hasGasTracker = config.UI.homepage.showGasTracker;
@@ -52,7 +51,9 @@ const Stats = () => {
     !data.gas_prices && itemsCount--;
     data.rootstock_locked_btc && itemsCount++;
     const isOdd = Boolean(itemsCount % 2);
-    const gasLabel = hasGasTracker && data.gas_prices ? <StatsGasPrices gasPrices={ data.gas_prices }/> : null;
+
+    const gasPriceRpc = data.gas_price_rpc && Number(data.gas_price_rpc).toLocaleString();
+    const gasPriceAverage = data.gas_prices && Number(data.gas_prices.average).toLocaleString();
 
     content = (
       <>
@@ -95,13 +96,12 @@ const Stats = () => {
           _last={ isOdd ? lastItemTouchStyle : undefined }
           isLoading={ isPlaceholderData }
         />
-        { hasGasTracker && data.gas_prices && (
+        { hasGasTracker && (gasPriceAverage || gasPriceAverage) && (
           <StatsItem
             icon={ gasIcon }
             title="Gas tracker"
-            value={ `${ Number(data.gas_prices.average).toLocaleString() } Gwei` }
+            value={ `${ gasPriceRpc || gasPriceAverage } Gwei` }
             _last={ isOdd ? lastItemTouchStyle : undefined }
-            tooltipLabel={ gasLabel }
             isLoading={ isPlaceholderData }
           />
         ) }


### PR DESCRIPTION
<img width="1487" alt="image" src="https://github.com/HorizenLabs/blockscout-frontend/assets/36055057/5bee5247-82a7-46c6-893f-fd0b67ddf65f">

This needs a PR also on the backend side, so the gas price that comes from the RPC it's exposed on the api/v2: https://github.com/HorizenLabs/eon-explorer/pull/63