### PR TITLE
[WEB3-698] Update Footer Links to display version of backend and frontend

### DIFF
--- a/ui/snippets/footer/Footer.tsx
+++ b/ui/snippets/footer/Footer.tsx
@@ -25,8 +25,8 @@ import getApiVersionUrl from './utils/getApiVersionUrl';
 
 const MAX_LINKS_COLUMNS = 4;
 
-const FRONT_VERSION_URL = `https://github.com/blockscout/frontend/tree/${ config.UI.footer.frontendVersion }`;
-const FRONT_COMMIT_URL = `https://github.com/blockscout/frontend/commit/${ config.UI.footer.frontendCommit }`;
+const FRONT_VERSION_URL = `https://github.com/HorizenLabs/blockscout-frontend/tree/${ config.UI.footer.frontendVersion }`;
+const FRONT_COMMIT_URL = `https://github.com/HorizenLabs/blockscout-frontend/commit/${ config.UI.footer.frontendCommit }`;
 
 const Footer = () => {
 

--- a/ui/snippets/footer/utils/getApiVersionUrl.tsx
+++ b/ui/snippets/footer/utils/getApiVersionUrl.tsx
@@ -6,8 +6,8 @@ export default function getApiVersionUrl(version: string | undefined): string | 
   const [ tag, commit ] = version.split('.+commit.');
 
   if (commit) {
-    return `https://github.com/blockscout/blockscout/commit/${ commit }`;
+    return `https://github.com/HorizenLabs/eon-explorer/commit/${ commit }`;
   }
 
-  return `https://github.com/blockscout/blockscout/tree/${ tag }`;
+  return `https://github.com/HorizenLabs/eon-explorer/tree/${ tag }`;
 }


### PR DESCRIPTION
In this PR, we have adjusted the links to display the current versions of both the frontend and backend. To achieve this, we modified the repository URLs to point to our fork rather than the original source.

It's important to note that the methods for rendering versions differ between the frontend and the backend.

For the backend, it retrieves the version information through an API call to the endpoint `/api/v2/config/backend-version`.

For the frontend, the version is determined by executing the command `git describe --tags --abbrev=0`, which describes the current commit using the nearest tag that is reachable from it.

<img width="826" alt="image" src="https://github.com/HorizenLabs/blockscout-frontend/assets/36055057/682bf755-05ba-42ad-92aa-79ed51fd7e96">
