### PR TITLE
[WEB3-772] Loading animation on transactions page on smaller screens

### DIFF
--- a/ui/txs/TxsContent.tsx
+++ b/ui/txs/TxsContent.tsx
@@ -67,11 +67,13 @@ const TxsContent = ({
               isLoading={ isPlaceholderData }
             />
           ) }
-          { data.items.map((tx, index) => (
-            isSpecialTxsContent ? (
+          { data.items.map((tx, index) => {
+            const castedTx = tx as unknown as SpecialTransaction;
+
+            return isSpecialTxsContent ? (
               <SpecialTxsListItem
-                key={ tx.hash + (isPlaceholderData ? index : '') }
-                tx={ tx as unknown as SpecialTransaction }
+                key={ castedTx.block_hash + (isPlaceholderData ? index : castedTx.index) }
+                tx={ castedTx }
                 showBlockInfo={ showBlockInfo }
                 currentAddress={ currentAddress }
                 enableTimeIncrement={ enableTimeIncrement }
@@ -86,8 +88,8 @@ const TxsContent = ({
                 enableTimeIncrement={ enableTimeIncrement }
                 isLoading={ isPlaceholderData }
               />
-            )
-          )) }
+            );
+          }) }
         </Box>
       </Show>
       <Hide below="lg" ssr={ false }>


### PR DESCRIPTION
It seems the issue was caused by improperly set keys for the items, preventing the removal of skeleton items after loading.

Now it works as expected.

<img width="528" alt="image" src="https://github.com/HorizenLabs/blockscout-frontend/assets/36055057/3b8cb3fb-df8a-42c8-bf84-aec7f83656b6">
