### PR TITLE
Hide sections for Native Smart Contracts

### DIFF
--- a/.env.eon
+++ b/.env.eon
@@ -1,5 +1,5 @@
 # APP CONFIGURATION
-NEXT_PUBLIC_APP_HOST=eon-explorer.horizenlabs.io
+NEXT_PUBLIC_APP_HOST=eon-explorer-api.horizenlabs.io
 
 # BLOCKCHAIN PARAMS
 NEXT_PUBLIC_NETWORK_NAME=Horizen EON Mainnet
@@ -12,7 +12,7 @@ NEXT_PUBLIC_NETWORK_VERIFICATION_TYPE=validation
 NEXT_PUBLIC_IS_TESTNET=false
 
 # API CONFIGURATION
-NEXT_PUBLIC_API_HOST=eon-explorer.horizenlabs.io
+NEXT_PUBLIC_API_HOST=eon-explorer-api.horizenlabs.io
 
 # HOMEPAGE
 NEXT_PUBLIC_HOMEPAGE_CHARTS=['daily_txs', 'coin_price']
@@ -20,21 +20,24 @@ NEXT_PUBLIC_HOMEPAGE_PLATE_TEXT_COLOR=white
 NEXT_PUBLIC_HOMEPAGE_PLATE_BACKGROUND=radial-gradient(103.03% 103.03% at 0% 0%, rgba(183, 148, 244, 0.8) 0%, rgba(0, 163, 196, 0.8) 100%), var(--chakra-colors-blue-400)
 
 # SIDEBAR
-NEXT_PUBLIC_NETWORK_LOGO=https://eon-explorer.horizenlabs.io/images/HEON-eon-dark.svg
-NEXT_PUBLIC_NETWORK_LOGO_DARK=https://eon-explorer.horizenlabs.io/images/HEON-eon-light.svg
-NEXT_PUBLIC_NETWORK_ICON=https://eon-explorer.horizenlabs.io/images/favicon-32x32.png
-NEXT_PUBLIC_NETWORK_ICON_DARK=https://eon-explorer.horizenlabs.io/images/favicon-32x32.png
+NEXT_PUBLIC_NETWORK_LOGO=https://eon-explorer-api.horizenlabs.io/images/HEON-eon-dark.svg
+NEXT_PUBLIC_NETWORK_LOGO_DARK=https://eon-explorer-api.horizenlabs.io/images/HEON-eon-light.svg
+NEXT_PUBLIC_NETWORK_ICON=https://eon-explorer-api.horizenlabs.io/images/favicon-32x32.png
+NEXT_PUBLIC_NETWORK_ICON_DARK=https://eon-explorer-api.horizenlabs.io/images/favicon-32x32.png
 NEXT_PUBLIC_OTHER_LINKS=[{'url': "https://postman.horizenlabs.io/", 'text': "JSON-RPC Documentation"}, {'url': "https://faucet.horizen.io/", 'text': "Testnet ZEN Faucet"}]
 
 # FOOTER
 NEXT_PUBLIC_FOOTER_LINKS=
 
 # FAVICON
-FAVICON_GENERATOR_API_KEY=87811573d5c5518da21c7c0b669f568bdd9e7004
+FAVICON_GENERATOR_API_KEY=
 
 # METADATA
 NEXT_PUBLIC_OG_DESCRIPTION=The Horizen EON Mainnet Block Explorer allows you to search the Horizen EON Mainnet Blockchain for transactions, addresses, statistics and activities taking place on-chain.
-NEXT_PUBLIC_OG_IMAGE_URL=https://eon-explorer.horizenlabs.io/images/MetaData_image_EON_mainnet_block_explorer.jpg
+NEXT_PUBLIC_OG_IMAGE_URL=https://eon-explorer-api.horizenlabs.io/images/MetaData_image_EON_mainnet_block_explorer.jpg
+
+# SWAGGER
+NEXT_PUBLIC_API_SPEC_URL=https://raw.githubusercontent.com/HorizenLabs/eon-explorer/master/apps/block_scout_web/swaggers/swagger-v2.yaml
 
 # FEATURES
 NEXT_PUBLIC_AD_BANNER_PROVIDER=none
@@ -43,4 +46,8 @@ NEXT_PUBLIC_AD_TEXT_PROVIDER=none
 # CSV
 # NEXT_PUBLIC_RE_CAPTCHA_APP_SITE_KEY=
 
+# GOOGLE ANALYTICS
 NEXT_PUBLIC_GOOGLE_ANALYTICS_PROPERTY_ID=G-HVZGW1WMC2
+
+# WALLET CONNECT
+NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID=aadb68239286cc80d0e10644b2aeb538

--- a/.env.gobi
+++ b/.env.gobi
@@ -1,5 +1,5 @@
 # APP CONFIGURATION
-NEXT_PUBLIC_APP_HOST=gobi-explorer.horizenlabs.io
+NEXT_PUBLIC_APP_HOST=gobi-explorer-api.horizenlabs.io
 
 # BLOCKCHAIN PARAMS
 NEXT_PUBLIC_NETWORK_NAME=Horizen Gobi Testnet
@@ -12,7 +12,7 @@ NEXT_PUBLIC_NETWORK_VERIFICATION_TYPE=validation
 NEXT_PUBLIC_IS_TESTNET=true
 
 # API CONFIGURATION
-NEXT_PUBLIC_API_HOST=gobi-explorer.horizenlabs.io
+NEXT_PUBLIC_API_HOST=gobi-explorer-api.horizenlabs.io
 
 # HOMEPAGE
 NEXT_PUBLIC_HOMEPAGE_CHARTS=['daily_txs', 'coin_price']
@@ -20,21 +20,24 @@ NEXT_PUBLIC_HOMEPAGE_PLATE_TEXT_COLOR=white
 NEXT_PUBLIC_HOMEPAGE_PLATE_BACKGROUND=radial-gradient(103.03% 103.03% at 0% 0%, rgba(183, 148, 244, 0.8) 0%, rgba(0, 163, 196, 0.8) 100%), var(--chakra-colors-blue-400)
 
 # SIDEBAR
-NEXT_PUBLIC_NETWORK_LOGO=https://gobi-explorer.horizenlabs.io/images/HEON-gobi.svg
-NEXT_PUBLIC_NETWORK_LOGO_DARK=https://gobi-explorer.horizenlabs.io/images/HEON-gobi-light.svg
-NEXT_PUBLIC_NETWORK_ICON=https://gobi-explorer.horizenlabs.io/images/favicon-32x32.png
-NEXT_PUBLIC_NETWORK_ICON_DARK=https://pre-gobi-explorer.horizen.io/images/favicon-32x32.png
+NEXT_PUBLIC_NETWORK_LOGO=https://gobi-explorer-api.horizenlabs.io/images/HEON-gobi.svg
+NEXT_PUBLIC_NETWORK_LOGO_DARK=https://gobi-explorer-api.horizenlabs.io/images/HEON-gobi-light.svg
+NEXT_PUBLIC_NETWORK_ICON=https://gobi-explorer-api.horizenlabs.io/images/favicon-32x32.png
+NEXT_PUBLIC_NETWORK_ICON_DARK=https://gobi-explorer-api.horizen.io/images/favicon-32x32.png
 NEXT_PUBLIC_OTHER_LINKS=[{'url': "https://postman.horizenlabs.io/", 'text': "JSON-RPC Documentation"}, {'url': "https://faucet.horizen.io/", 'text': "Testnet ZEN Faucet"}]
 
 # FOOTER
 NEXT_PUBLIC_FOOTER_LINKS=
 
 # FAVICON
-FAVICON_GENERATOR_API_KEY=87811573d5c5518da21c7c0b669f568bdd9e7004
+FAVICON_GENERATOR_API_KEY=
 
 # METADATA
 NEXT_PUBLIC_OG_DESCRIPTION=The Horizen Gobi Testnet Block Explorer allows you to search the Horizen Gobi Testnet Blockchain for transactions, addresses, statistics and activities taking place on-chain.
-NEXT_PUBLIC_OG_IMAGE_URL=https://gobi-explorer.horizenlabs.io/images/MetaData_img_blueprint_gobi_explorer.jpg
+NEXT_PUBLIC_OG_IMAGE_URL=https://gobi-explorer-api.horizenlabs.io/images/MetaData_img_blueprint_gobi_explorer.jpg
+
+# SWAGGER
+NEXT_PUBLIC_API_SPEC_URL=https://raw.githubusercontent.com/HorizenLabs/eon-explorer/master/apps/block_scout_web/swaggers/swagger-v2.yaml
 
 # FEATURES
 NEXT_PUBLIC_AD_BANNER_PROVIDER=none
@@ -43,4 +46,8 @@ NEXT_PUBLIC_AD_TEXT_PROVIDER=none
 # CSV
 # NEXT_PUBLIC_RE_CAPTCHA_APP_SITE_KEY=
 
+# GOOGLE ANALYTICS
 NEXT_PUBLIC_GOOGLE_ANALYTICS_PROPERTY_ID=G-HVZGW1WMC2
+
+# WALLET CONNECT
+NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID=aadb68239286cc80d0e10644b2aeb538

--- a/.env.pregobi
+++ b/.env.pregobi
@@ -1,5 +1,5 @@
 # APP CONFIGURATION
-NEXT_PUBLIC_APP_HOST=pre-gobi-explorer.horizenlabs.io
+NEXT_PUBLIC_APP_HOST=pregobi-explorer-api.horizenlabs.io
 
 # BLOCKCHAIN PARAMS
 NEXT_PUBLIC_NETWORK_NAME=Horizen Pre-Gobi Testnet
@@ -12,7 +12,7 @@ NEXT_PUBLIC_NETWORK_VERIFICATION_TYPE=validation
 NEXT_PUBLIC_IS_TESTNET=true
 
 # API CONFIGURATION
-NEXT_PUBLIC_API_HOST=pre-gobi-explorer.horizen.io
+NEXT_PUBLIC_API_HOST=pregobi-explorer-api.horizenlabs.io
 
 # HOMEPAGE
 NEXT_PUBLIC_HOMEPAGE_CHARTS=['daily_txs', 'coin_price']
@@ -20,21 +20,24 @@ NEXT_PUBLIC_HOMEPAGE_PLATE_TEXT_COLOR=white
 NEXT_PUBLIC_HOMEPAGE_PLATE_BACKGROUND=radial-gradient(103.03% 103.03% at 0% 0%, rgba(183, 148, 244, 0.8) 0%, rgba(0, 163, 196, 0.8) 100%), var(--chakra-colors-blue-400)
 
 # SIDEBAR
-NEXT_PUBLIC_NETWORK_LOGO=https://pre-gobi-explorer.horizen.io/images/HEON-gobi.svg
-NEXT_PUBLIC_NETWORK_LOGO_DARK=https://pre-gobi-explorer.horizen.io/images/HEON-gobi-light.svg
-NEXT_PUBLIC_NETWORK_ICON=https://pre-gobi-explorer.horizen.io/images/favicon-32x32.png
-NEXT_PUBLIC_NETWORK_ICON_DARK=https://pre-gobi-explorer.horizen.io/images/favicon-32x32.png
+NEXT_PUBLIC_NETWORK_LOGO=https://pregobi-explorer-api.horizenlabs.io/images/HEON-gobi.svg
+NEXT_PUBLIC_NETWORK_LOGO_DARK=https://pregobi-explorer-api.horizenlabs.io/images/HEON-gobi-light.svg
+NEXT_PUBLIC_NETWORK_ICON=https://pregobi-explorer-api.horizenlabs.io/images/favicon-32x32.png
+NEXT_PUBLIC_NETWORK_ICON_DARK=https://pregobi-explorer-api.horizenlabs.io/images/favicon-32x32.png
 NEXT_PUBLIC_OTHER_LINKS=[{'url': "https://postman.horizenlabs.io/", 'text': "JSON-RPC Documentation"}, {'url': "https://faucet.horizen.io/", 'text': "Testnet ZEN Faucet"}]
 
 # FOOTER
 NEXT_PUBLIC_FOOTER_LINKS=
 
 # FAVICON
-FAVICON_GENERATOR_API_KEY=87811573d5c5518da21c7c0b669f568bdd9e7004
+FAVICON_GENERATOR_API_KEY=
 
 # METADATA
 NEXT_PUBLIC_OG_DESCRIPTION=The Horizen Gobi Testnet Block Explorer allows you to search the Horizen Gobi Testnet Blockchain for transactions, addresses, statistics and activities taking place on-chain.
-NEXT_PUBLIC_OG_IMAGE_URL=https://pre-gobi-explorer.horizen.io/images/MetaData_img_blueprint_gobi_explorer.jpg
+NEXT_PUBLIC_OG_IMAGE_URL=https://pregobi-explorer-api.horizenlabs.io/images/MetaData_img_blueprint_gobi_explorer.jpg
+
+# SWAGGER
+NEXT_PUBLIC_API_SPEC_URL=https://raw.githubusercontent.com/HorizenLabs/eon-explorer/master/apps/block_scout_web/swaggers/swagger-v2.yaml
 
 # FEATURES
 NEXT_PUBLIC_AD_BANNER_PROVIDER=none
@@ -43,4 +46,8 @@ NEXT_PUBLIC_AD_TEXT_PROVIDER=none
 # CSV
 # NEXT_PUBLIC_RE_CAPTCHA_APP_SITE_KEY=
 
+# GOOGLE ANALYTICS
 NEXT_PUBLIC_GOOGLE_ANALYTICS_PROPERTY_ID=G-HVZGW1WMC2
+
+# WALLET CONNECT
+NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID=aadb68239286cc80d0e10644b2aeb538

--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ Alternatively, you can build your own docker image and run your app from that. P
 For more information on migrating from the previous frontend, please see the [frontend migration docs](https://docs.blockscout.com/for-developers/frontend-migration).
 
 ## Running locally in dev mode
-Place an env file inside `/config/envs/.env.local`. Make sure the env file has a port number set: `NEXT_PUBLIC_APP_PORT=8000`.
+Place an env file inside `/config/envs/.env.local`. Make sure the env file has a port number set: `NEXT_PUBLIC_APP_PORT=3000`.
 
 `.env.pregobi`, `.env.gobi`, or `.env.eon` can be used as a template.
 
-Run `yarn dev:preset local`. The app will run on port 8000, as set in the env file.
+Run `yarn dev:preset local`. The app will run on port 3000, as set in the env file.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -21,9 +21,11 @@ Alternatively, you can build your own docker image and run your app from that. P
 For more information on migrating from the previous frontend, please see the [frontend migration docs](https://docs.blockscout.com/for-developers/frontend-migration).
 
 ## Running locally in dev mode
-Place an env file inside `/config/envs/.env.local`. Make sure the env file has a port number set: `NEXT_PUBLIC_APP_PORT=8000`
+Place an env file inside `/config/envs/.env.local`. Make sure the env file has a port number set: `NEXT_PUBLIC_APP_PORT=8000`.
 
-Run `yarn dev:preset local`. The app will run on port 8000, as set in the env variable.
+`.env.pregobi`, `.env.gobi`, or `.env.eon` can be used as a template.
+
+Run `yarn dev:preset local`. The app will run on port 8000, as set in the env file.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ For more information on migrating from the previous frontend, please see the [fr
 ## Running locally in dev mode
 Place an env file inside `/config/envs/.env.local`. Make sure the env file has a port number set: `NEXT_PUBLIC_APP_PORT=8000`
 
-Run `yarn dev:preset localhost`. The app will run on port 8000, as set in the env variable.
+Run `yarn dev:preset local`. The app will run on port 8000, as set in the env variable.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ Alternatively, you can build your own docker image and run your app from that. P
 
 For more information on migrating from the previous frontend, please see the [frontend migration docs](https://docs.blockscout.com/for-developers/frontend-migration).
 
+## Running locally in dev mode
+Place an env file inside `/config/envs/.env.local`. Make sure the env file has a port number set: `NEXT_PUBLIC_APP_PORT=8000`
+
+Run `yarn dev:preset localhost`. The app will run on port 8000, as set in the env variable.
+
 ## Contributing
 
 See our [Contribution guide](./docs/CONTRIBUTING.md) for pull request protocol. We expect contributors to follow our [code of conduct](./CODE_OF_CONDUCT.md) when submitting code or comments.

--- a/ui/address/contract/ContractCode.tsx
+++ b/ui/address/contract/ContractCode.tsx
@@ -242,7 +242,8 @@ const ContractCode = ({ addressHash, noSocket }: Props) => {
             isLoading={ isPlaceholderData }
           />
         ) }
-        { data?.source_code && (
+        { /* source_code is '/' for all native smart contracts */ }
+        { data?.source_code && data?.source_code !== '/' && (
           <ContractSourceCode
             address={ addressHash }
             implementationAddress={ addressInfo?.implementation_address ?? undefined }
@@ -279,7 +280,8 @@ const ContractCode = ({ addressHash, noSocket }: Props) => {
             isLoading={ isPlaceholderData }
           />
         ) }
-        { data?.deployed_bytecode && (
+        { /* deployed_bytecode is '0x2f' for all native smart contracts */ }
+        { data?.deployed_bytecode && data?.deployed_bytecode !== '0x2f' && (
           <RawDataSnippet
             data={ data.deployed_bytecode }
             title="Deployed ByteCode"

--- a/ui/address/contract/ContractCode.tsx
+++ b/ui/address/contract/ContractCode.tsx
@@ -19,6 +19,7 @@ import LinkInternal from 'ui/shared/LinkInternal';
 import RawDataSnippet from 'ui/shared/RawDataSnippet';
 
 import ContractSourceCode from './ContractSourceCode';
+import { isNativeSmartContract } from './utils';
 
 type Props = {
   addressHash?: string;
@@ -181,7 +182,7 @@ const ContractCode = ({ addressHash, noSocket }: Props) => {
           </Skeleton>
         ) }
         { verificationAlert }
-        { (data?.is_changed_bytecode || isChangedBytecodeSocket) && (
+        { (data?.is_changed_bytecode || isChangedBytecodeSocket) && !isNativeSmartContract(addressHash) && (
           <Alert status="warning">
             Warning! Contract bytecode has been changed and does not match the verified one. Therefore, interaction with this smart contract may be risky.
           </Alert>
@@ -242,8 +243,7 @@ const ContractCode = ({ addressHash, noSocket }: Props) => {
             isLoading={ isPlaceholderData }
           />
         ) }
-        { /* source_code is '/' for all native smart contracts */ }
-        { data?.source_code && data?.source_code !== '/' && (
+        { data?.source_code && !isNativeSmartContract(addressHash) && (
           <ContractSourceCode
             address={ addressHash }
             implementationAddress={ addressInfo?.implementation_address ?? undefined }
@@ -280,8 +280,7 @@ const ContractCode = ({ addressHash, noSocket }: Props) => {
             isLoading={ isPlaceholderData }
           />
         ) }
-        { /* deployed_bytecode is '0x2f' for all native smart contracts */ }
-        { data?.deployed_bytecode && data?.deployed_bytecode !== '0x2f' && (
+        { data?.deployed_bytecode && !isNativeSmartContract(addressHash) && (
           <RawDataSnippet
             data={ data.deployed_bytecode }
             title="Deployed ByteCode"

--- a/ui/address/contract/utils.test.ts
+++ b/ui/address/contract/utils.test.ts
@@ -1,4 +1,10 @@
-import { prepareAbi } from './utils';
+import { prepareAbi,
+  isNativeSmartContract,
+  WITHDRAWAL_REQUEST_CONTRACT,
+  FORGER_STAKE_CONTRACT,
+  FORGER_STAKE_V2_CONTRACT,
+  CERTIFCATE_KEY_ROTATION_CONTRACT,
+  MC_ADDRESS_OWNERSHIP_CONTRACT } from './utils';
 
 describe('function prepareAbi()', () => {
   const commonAbi = [
@@ -96,5 +102,18 @@ describe('function prepareAbi()', () => {
 
     const item = abi.find((item) => 'name' in item ? item.name === method.name : false);
     expect(item).toEqual(commonAbi[2]);
+  });
+});
+
+describe('isNativeSmartContract()', () => {
+  test.each([ WITHDRAWAL_REQUEST_CONTRACT, FORGER_STAKE_CONTRACT, FORGER_STAKE_V2_CONTRACT, CERTIFCATE_KEY_ROTATION_CONTRACT, MC_ADDRESS_OWNERSHIP_CONTRACT ])(
+    'returns true if address is a native contract address',
+    (addr) => {
+      expect(isNativeSmartContract(addr)).toBe(true);
+    },
+  );
+
+  it('returns false if address it not a native contract address', () => {
+    expect(isNativeSmartContract('0x42128B43F84654A7A16E30f9ADdF390367F81121')).toBe(false);
   });
 });

--- a/ui/address/contract/utils.ts
+++ b/ui/address/contract/utils.ts
@@ -2,6 +2,12 @@ import type { Abi } from 'abitype';
 
 import type { SmartContractWriteMethod } from 'types/api/contract';
 
+export const WITHDRAWAL_REQUEST_CONTRACT = '0x0000000000000000000011111111111111111111';
+export const FORGER_STAKE_CONTRACT = '0x0000000000000000000022222222222222222222';
+export const FORGER_STAKE_V2_CONTRACT = '0x0000000000000000000022222222222222222333';
+export const CERTIFCATE_KEY_ROTATION_CONTRACT = '0x0000000000000000000044444444444444444444';
+export const MC_ADDRESS_OWNERSHIP_CONTRACT = '0x0000000000000000000088888888888888888888';
+
 export const getNativeCoinValue = (value: string | Array<unknown>) => {
   const _value = Array.isArray(value) ? value[0] : value;
 
@@ -74,4 +80,14 @@ export function prepareAbi(abi: Abi, item: SmartContractWriteMethod): Abi {
   }
 
   return abi;
+}
+
+export function isNativeSmartContract(address: string) {
+  return [
+    WITHDRAWAL_REQUEST_CONTRACT,
+    FORGER_STAKE_CONTRACT,
+    FORGER_STAKE_V2_CONTRACT,
+    CERTIFCATE_KEY_ROTATION_CONTRACT,
+    MC_ADDRESS_OWNERSHIP_CONTRACT,
+  ].includes(address);
 }


### PR DESCRIPTION
- Add instructions to readme on how to run locally in dev mode 
- Update .env files for pregobi, gobi, and eon to match the ones used in [compose-eon-explorer](https://github.com/HorizenLabs/compose-eon-explorer/tree/main/env)
- Hide "contract source code", "deployed byte code" and "bytecode changed" warning for native smart contracts
  - The API is incorrectly returning `is_changed_bytecode: true`, but easier to adjust the UI

<img width="1788" alt="Screen Shot 2024-06-12 at 3 00 41 PM" src="https://github.com/HorizenLabs/blockscout-frontend/assets/20520369/ed369f77-bca4-40d6-93fb-611af0c3906e">

<img width="378" alt="Screen Shot 2024-06-12 at 3 01 39 PM" src="https://github.com/HorizenLabs/blockscout-frontend/assets/20520369/72c11a51-ffde-47b2-ac87-7f48dae1361f">
